### PR TITLE
morgan pkg minver update

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express": "~4.13.1",
     "jsonwebtoken": "^5.0.4",
     "mongoose": "^4.1.0",
-    "morgan": "~1.6.1",
+    "morgan": "~1.9.1",
     "passport": "^0.2.2",
     "passport-local": "^1.0.0",
     "serve-favicon": "~2.3.0"


### PR DESCRIPTION
# `morgan` Security Alert Remediation

> Upgrade morgan to version 1.9.1 or later. For example:

```
"dependencies": {
  "morgan": ">=1.9.1"
}
```
or…
```
"devDependencies": {
  "morgan": ">=1.9.1"
}
```
_Always verify the validity and compatibility of suggestions with your codebase._

## Details

### CVE-2019-5413 More information
**_moderate severity_
Vulnerable versions: < 1.9.1
Patched version: 1.9.1**

An attacker can use the format parameter to inject arbitrary commands in the npm package morgan < 1.9.1.