### PR TITLE
update debug pkg minver

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "body-parser": "~1.13.2",
     "cookie-parser": "~1.3.5",
-    "debug": "~2.2.0",
+    "debug": "~2.6.9",
     "ejs": "~2.5.5",
     "express": "~4.13.1",
     "jsonwebtoken": "^5.0.4",


### PR DESCRIPTION
# `debug` Security Alert Remediation

> Upgrade debug to version 2.6.9 or later. For example:
```
"dependencies": {
  "debug": ">=2.6.9"
}
```
or…
```
"devDependencies": {
  "debug": ">=2.6.9"
}
```
_Always verify the validity and compatibility of suggestions with your codebase._

## Details
### CVE-2017-16137
**_low severity_
Vulnerable versions: < 2.6.9
Patched version: 2.6.9**

The debug module is vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter. It takes around 50k characters to block for 2 seconds making this a low severity issue.